### PR TITLE
Add GitHub webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 vendor/
 # executable
 kabanero-webhook
+
+### Intellij ###
+.idea
+out/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ COPY *.go ./
 # Linter
 RUN go get -u golang.org/x/lint/golint; golint -set_exit_status
 
-RUN go get -u gopkg.in/go-playground/webhooks.v3/github
-
 # Run unit test
 # COPY test_data ./test_data/
 # RUN go test -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY *.go ./
 # Linter
 RUN go get -u golang.org/x/lint/golint; golint -set_exit_status
 
+RUN go get -u gopkg.in/go-playground/webhooks.v3/github
+
 # Run unit test
 # COPY test_data ./test_data/
 # RUN go test -v
@@ -65,6 +67,7 @@ COPY --chown=1001:0 licenses/ /licenses/
 # COPY --chown=1001:0 testcntlr.sh /bin/testcntlr.sh
 USER 1001
 WORKDIR /app
+EXPOSE 8080
 
 # run with log level 2
 # Note liveness/readiness probe depends on './webhook'

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,14 +9,6 @@
   revision = "782f4967f2dc4564575ca782fe2d04090b5faca8"
 
 [[projects]]
-  branch = "master"
-  digest = "1:36a5ff9459163d104f2af9776c8db63f3eb4339f527a00a9835c8d562eb116ba"
-  name = "github.com/evanphx/json-patch"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "5858425f75500d40c52783dce87d085a483ce135"
-
-[[projects]]
   digest = "1:b7a8552c62868d867795b63eaf4f45d3e92d36db82b428e680b9c95a8c33e5b1"
   name = "github.com/gogo/protobuf"
   packages = [
@@ -42,6 +34,22 @@
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:91099c6f78b1e7bdf9ed06eb4cb7f017174293a3689d76b995a06f4c8d64a7f0"
+  name = "github.com/google/go-github"
+  packages = ["github"]
+  pruneopts = "UT"
+  revision = "9686ff0746200cf521ce225525b421e13b4eac1a"
+  version = "v28.1.1"
+
+[[projects]]
+  digest = "1:a63cff6b5d8b95638bfe300385d93b2a6d9d687734b863da8e09dc834510a690"
+  name = "github.com/google/go-querystring"
+  packages = ["query"]
+  pruneopts = "UT"
+  revision = "44c6ddd0a2342c386950e880b658017258da92fc"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   digest = "1:3ee90c0d94da31b442dde97c99635aaafec68d0b8a3c12ee2075c6bdabeec6bb"
   name = "github.com/google/gofuzz"
@@ -60,17 +68,6 @@
   pruneopts = "UT"
   revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
   version = "v0.2.0"
-
-[[projects]]
-  digest = "1:8ec8d88c248041a6df5f6574b87bc00e7e0b493881dad2e7ef47b11dc69093b5"
-  name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru",
-  ]
-  pruneopts = "UT"
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
 
 [[projects]]
   digest = "1:3e260afa138eab6492b531a3b3d10ab4cb70512d423faa78b8949dec76e66a21"
@@ -113,9 +110,18 @@
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
+  digest = "1:991580c38dc517fe91ce3c165958a4fc2d2d7bcc0d3594883df296ed29b2ffad"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "cast5",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "ssh/terminal",
+  ]
   pruneopts = "UT"
   revision = "de0752318171da717af4ce24d0a2e8626afaeb11"
 
@@ -261,13 +267,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5e8a5b86e19194c44469c8ffb49f13a26a210df4ec0177bdc65dcb70083604f1"
+  digest = "1:97f690e88b67728656d37740d16daeaf0e22c0ecd8b0c7793747c3f156c40858"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
     "pkg/api/meta",
     "pkg/api/resource",
-    "pkg/apis/meta/internalversion",
     "pkg/apis/meta/v1",
     "pkg/apis/meta/v1/unstructured",
     "pkg/apis/meta/v1beta1",
@@ -285,26 +290,20 @@
     "pkg/runtime/serializer/versioning",
     "pkg/selection",
     "pkg/types",
-    "pkg/util/cache",
     "pkg/util/clock",
-    "pkg/util/diff",
     "pkg/util/errors",
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
-    "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
-    "pkg/util/strategicpatch",
     "pkg/util/validation",
     "pkg/util/validation/field",
-    "pkg/util/wait",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
-    "third_party/forked/golang/json",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
@@ -312,12 +311,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4f8705a2574056ffe4043a3ac1c02b55390479fef97acb9d828268c3117a73f7"
+  digest = "1:47c2165dcaa1a0d40ef688c0820502cf6c7f4324da876ea834f0d992a058e3cf"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
     "dynamic",
-    "dynamic/fake",
     "kubernetes",
     "kubernetes/scheme",
     "kubernetes/typed/admissionregistration/v1beta1",
@@ -361,15 +359,12 @@
     "plugin/pkg/client/auth/exec",
     "rest",
     "rest/watch",
-    "testing",
     "tools/auth",
-    "tools/cache",
     "tools/clientcmd",
     "tools/clientcmd/api",
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
     "tools/metrics",
-    "tools/pager",
     "tools/reference",
     "transport",
     "util/cert",
@@ -377,8 +372,6 @@
     "util/flowcontrol",
     "util/homedir",
     "util/keyutil",
-    "util/retry",
-    "util/workqueue",
   ]
   pruneopts = "UT"
   revision = "9c9f7f424e65af6ded246bd4ba1a1cec988acc7b"
@@ -392,21 +385,10 @@
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:03a96603922fc1f6895ae083e1e16d943b55ef0656b56965351bd87e7d90485f"
-  name = "k8s.io/kube-openapi"
-  packages = ["pkg/util/proto"]
-  pruneopts = "UT"
-  revision = "b3a7cee44a305be0a69e1b9ac03018307287e1b0"
-
-[[projects]]
   branch = "master"
-  digest = "1:14e8a3b53e6d8cb5f44783056b71bb2ca1ac7e333939cc97f3e50b579c920845"
+  digest = "1:8b40227d4bf8b431fdab4f9026e6e346f00ac3be5662af367a183f78c57660b3"
   name = "k8s.io/utils"
-  packages = [
-    "buffer",
-    "integer",
-    "trace",
-  ]
+  packages = ["integer"]
   pruneopts = "UT"
   revision = "c2654d5206da6b7b6ace12841e8f359bb89b443c"
 
@@ -422,24 +404,15 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/googleapis/gnostic/OpenAPIv2",
+    "github.com/google/go-github/github",
     "k8s.io/api/core/v1",
-    "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-    "k8s.io/apimachinery/pkg/runtime",
-    "k8s.io/apimachinery/pkg/runtime/schema",
-    "k8s.io/apimachinery/pkg/util/runtime",
-    "k8s.io/apimachinery/pkg/version",
     "k8s.io/apimachinery/pkg/watch",
-    "k8s.io/client-go/discovery",
     "k8s.io/client-go/dynamic",
-    "k8s.io/client-go/dynamic/fake",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/rest",
-    "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
     "k8s.io/client-go/util/homedir",
-    "k8s.io/client-go/util/workqueue",
     "k8s.io/klog",
   ]
   solver-name = "gps-cdcl"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -207,6 +207,17 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:39f43a9ea4af920abf322d1770c5fbf337286cb174a25827b22e1da72dcfdb5c"
+  name = "gopkg.in/go-playground/webhooks.v3"
+  packages = [
+    ".",
+    "github",
+  ]
+  pruneopts = "UT"
+  revision = "8ffb2ffc32b7af2c7e940944eccba4dcd66c692a"
+  version = "v3.13.0"
+
+[[projects]]
   digest = "1:ef72505cf098abdd34efeea032103377bec06abb61d8a06f002d5d296a4b1185"
   name = "gopkg.in/inf.v0"
   packages = ["."]
@@ -405,6 +416,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/google/go-github/github",
+    "gopkg.in/go-playground/webhooks.v3/github",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/watch",

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ If you import new prerequisites in your source code:
 - Re-run both the unit test and buld.
 - Push the updated `Gopkg.lock` and `Gopkg.toml`. 
 
+#### Running in OpenShift
+Running Kabanero Webhook in OpenShift can be done using `oc new-app` like so:
+```bash
+oc new-app kabanero/webhook -e GH_USER=<github-username> -e GH_TOKEN=<github-token> -e GH_URL=https://api.github.ibm.com
+```
+
+The environment variables `GH_USER` and `GH_TOKEN` are necessary at the moment to be able to use GitHub's API. This
+configuration will eventually be read from a Kubernetes Secret.
+
+The environment variable `GH_URL` is only necessary for GitHub Enterprise. It should be set to your GHE's API URL.
 
 <a name="Functional_Spec"></a>
 ## Functional Specifications

--- a/github.go
+++ b/github.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"github.com/google/go-github/github"
+	"io/ioutil"
+	"k8s.io/klog"
+	"net/http"
+	"os"
+	"strings"
+	ghw "gopkg.in/go-playground/webhooks.v3/github"
+)
+
+// Event A GitHub Event
+type Event string
+
+// EventHandler Handler for an event
+type EventHandler func(*http.Request) (interface{}, error)
+
+// GitHubListener Event listener for GitHub events
+type GitHubListener struct {
+	Client *github.Client
+	Events  map[Event]EventHandler
+}
+
+var (
+	// ErrInvalidHTTPMethod Only support the POST HTTP method for webhooks
+    ErrInvalidHTTPMethod = errors.New("invalid HTTP method; must use HTTP POST")
+
+    // ErrMissingGitHubEventHeader X-GitHub-Event header is required for GH payloads
+    ErrMissingGitHubEventHeader = errors.New("missing X-GitHub-Event header")
+
+    // ErrInvalidPayload Payload was invalid
+    ErrInvalidPayload = errors.New("unable to parse event payload")
+
+    // ErrUnknownEvent Event is either unknown or unsupported
+    ErrUnknownEvent = errors.New("unknown or unsupported event")
+
+    // ErrConnection Unable to connect to GH/GHE
+    ErrConnection = errors.New("connection to GitHub failed")
+
+    // ErrUserNameNotFound The GH_USER environment variable is required for the GitHub listener
+    ErrUserNameNotFound = errors.New("GH_USER environment variable is required")
+
+    // ErrTokenNotFound The GH_TOKEN environment variable is required for the GitHub listener
+	ErrTokenNotFound = errors.New("GH_TOKEN environment variable is required")
+)
+
+const (
+	// PushEvent GH Push event
+	PushEvent Event = "push"
+)
+
+// NewGitHubEventListener Create a new GitHubListener
+func NewGitHubEventListener() (*GitHubListener, error) {
+	// TODO: Read GH URL from CRD?
+	githubURL := strings.TrimSpace(os.Getenv("GH_URL"))
+
+	// TODO: Switch to Secret
+	username := strings.TrimSpace(os.Getenv("GH_USER"))
+	password := strings.TrimSpace(os.Getenv("GH_TOKEN"))
+
+	if username == "" {
+		return nil, ErrUserNameNotFound
+	}
+
+	if password == "" {
+		return nil, ErrTokenNotFound
+	}
+
+	tp := github.BasicAuthTransport{
+		Username: username,
+		Password: password,
+	}
+
+	var client *github.Client
+	var err error
+
+	if githubURL == "" {
+		client = github.NewClient(tp.Client())
+	} else {
+		client, err = github.NewEnterpriseClient(githubURL, githubURL, tp.Client())
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	listener := new(GitHubListener)
+	listener.Client = client
+	listener.Events = make(map[Event]EventHandler)
+	listener.Events[PushEvent] = handlePushEvent
+	return listener, nil
+}
+
+// ParseEvent Parse GH and GHE events.
+func (listener *GitHubListener) ParseEvent(r *http.Request) (interface{}, error) {
+	if r.Method != http.MethodPost {
+		return nil, ErrInvalidHTTPMethod
+	}
+
+	event := Event(r.Header.Get("X-GitHub-Event"))
+
+	if event == "" {
+		return nil, ErrMissingGitHubEventHeader
+	}
+
+	if eventHandler := listener.Events[event]; eventHandler != nil {
+		return eventHandler(r)
+	}
+
+	return nil, ErrUnknownEvent
+}
+
+// GetFile Retrieve file contents from a GitHub repository
+func (listener *GitHubListener) GetFile(owner, repo, path string) (string, error) {
+	rc, err := listener.Client.Repositories.DownloadContents(context.Background(), owner, repo, path, nil)
+	//rc.Close()
+
+	if err != nil {
+		return "", err
+	}
+
+	if buf, err := ioutil.ReadAll(rc); err == nil {
+		return string(buf), nil
+	}
+
+	return "", err
+}
+
+func getPayload(r *http.Request, eventPayload interface{}) error {
+	payload, err := ioutil.ReadAll(r.Body)
+
+	if err != nil || len(payload) == 0 {
+		return ErrInvalidPayload
+	}
+
+	return json.Unmarshal([]byte(payload), eventPayload)
+}
+
+func handlePushEvent(r *http.Request) (interface{}, error) {
+	var payload ghw.PushPayload
+	err := getPayload(r, &payload)
+	if err != nil {
+		klog.Error(err)
+		return nil, err
+	}
+
+	return payload, nil
+}
+
+// GetOwnerAndRepo Get the owner and repo of a Git repository
+func GetOwnerAndRepo(gitURL string) (string, string) {
+	// Strip off the Git URL and .git suffix, leaving owner/repo
+	gitURL = gitURL[strings.Index(gitURL, ":") + 1:]
+	gitURL = gitURL[:len(gitURL) - 4]
+	ownerAndRepo := strings.Split(gitURL, "/")
+	return ownerAndRepo[0], ownerAndRepo[1]
+}

--- a/main.go
+++ b/main.go
@@ -116,19 +116,9 @@ func main() {
 		payload, err := gitHubListener.ParseEvent(r)
 
 		if err == nil {
-
 			switch payload.(type) {
 			case ghw.PushPayload:
-				pushPayload := payload.(ghw.PushPayload)
 				klog.Infof("Received Push event:\n%v\n", payload)
-
-				owner, repo := GetOwnerAndRepo(pushPayload.Repository.SSHURL)
-				appsodyConfig, err := gitHubListener.GetFile(owner, repo, ".appsody-config.yaml")
-				if err == nil {
-					klog.Infof("Appsody information from repo: %s", appsodyConfig)
-				} else {
-					klog.Error(err)
-				}
 			}
 		} else {
 			klog.Error(err)


### PR DESCRIPTION
These changes add the GitHub webhook listener and currently only processes Push events. It also is able to read the `.appsody-config.yaml` file from the repo that the event is from.

The Tekton piece where we write out the Pipeline and related resources still needs to be done.