### PR TITLE
Use TLS listener if cert is provided.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ COPY --chown=1001:0 licenses/ /licenses/
 # COPY --chown=1001:0 testcntlr.sh /bin/testcntlr.sh
 USER 1001
 WORKDIR /app
-EXPOSE 8080
+EXPOSE 9443
 
 # run with log level 2
 # Note liveness/readiness probe depends on './webhook'

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ var (
 	dynamicClient    dynamic.Interface
 	webhookNamespace string
 	triggerProc      *triggerProcessor
+	disableTLS       bool
 )
 
 func init() {
@@ -266,6 +267,7 @@ func init() {
 		flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	flag.BoolVar(&disableTLS, "disableTLS", false, "set to use non-TLS listener")
 
 	// init falgs for klog
 	klog.InitFlags(nil)


### PR DESCRIPTION
Additional changes would be needed to the kabanero-webhook.yaml that Timothy Kaczynski provided to us:
```diff
diff --git a/config/orchestrations/webhook/0.1/kabanero-webhook.yaml b/config/orchestrations/webhook/0.1/kabanero-webhook.yaml
index e089d60..0c44520 100644
--- a/config/orchestrations/webhook/0.1/kabanero-webhook.yaml
+++ b/config/orchestrations/webhook/0.1/kabanero-webhook.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kabanero-webhook
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: kabanero-webhook-serving-cert
 spec:
   selector:
     app: kabanero-webhook
@@ -19,7 +21,7 @@ spec:
     kind: Service
     name: kabanero-webhook
   tls:
-    termination: passthrough
+    termination: reencrypt
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -115,4 +117,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-
+          volumeMounts:
+          - mountPath: /etc/tls
+            name: kabanero-webhook-serving-cert
+            readOnly: true
+      volumes:
+      - name: kabanero-webhook-serving-cert
+        secret:
+          secretName: kabanero-webhook-serving-cert
```