### PR TITLE
Verify triggers checksum.

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func main() {
 		// not overriden, use the one in the kabanero CRD
 		kabaneroIndexURL, err = getKabaneroIndexURL(dynamicClient, webhookNamespace)
 		if err != nil {
-			klog.Fatal(fmt.Errorf("Unable to get kabanero index URL from kabanero CRD. Error: %s", err))
+			klog.Fatal(fmt.Errorf("unable to get kabanero index URL from kabanero CRD. Error: %s", err))
 		}
 	} else {
 		klog.Infof("Using value of KABANERO_INDEX_URL environment variable to fetch kabanero index from: %s", kabaneroIndexURL)
@@ -131,20 +131,20 @@ func main() {
 	/* Download the trigger into temp directory */
 	dir, err := ioutil.TempDir("", "webhook")
 	if err != nil {
-		klog.Fatal(fmt.Errorf("Unable to create temproary directory. Error: %s", err))
+		klog.Fatal(fmt.Errorf("unable to create temproary directory. Error: %s", err))
 	}
 	defer os.RemoveAll(dir)
 
 	err = downloadTrigger(kabaneroIndexURL, dir)
 	if err != nil {
-		klog.Fatal(fmt.Errorf("Unable to download trigger pointed by kabanero_index_url at: %s, error: %s", kabaneroIndexURL, err))
+		klog.Fatal(fmt.Errorf("unable to download trigger pointed by kabanero_index_url at: %s, error: %s", kabaneroIndexURL, err))
 	}
 
 	triggerFileName := filepath.Join(dir, "eventTriggers.yaml")
 	triggerProc = &triggerProcessor{}
 	err = triggerProc.initialize(triggerFileName)
 	if err != nil {
-		klog.Fatal(fmt.Errorf("Unable to initialize trigger definition: %s", err))
+		klog.Fatal(fmt.Errorf("unable to initialize trigger definition: %s", err))
 	}
 
 	// gvr := schema.GroupVersionResource { Group: "app.k8s.io", Version: "v1beta1", Resource: "applications" }

--- a/main.go
+++ b/main.go
@@ -50,16 +50,17 @@ const (
 )
 
 var (
-	masterURL        string          // URL of Kube master
-	kubeconfig       string          // path to kube config file. default <home>/.kube/config
-	klogFlags        *flag.FlagSet   // flagset for logging
-	gitHubListener   *GitHubListener // Listens for and handles GH events
-	kubeClient       *kubernetes.Clientset
-	discClient       *discovery.DiscoveryClient
-	dynamicClient    dynamic.Interface
-	webhookNamespace string
-	triggerProc      *triggerProcessor
-	disableTLS       bool
+	masterURL            string                      // URL of Kube master
+	kubeconfig           string                      // path to kube config file. default <home>/.kube/config
+	klogFlags            *flag.FlagSet               // flagset for logging
+	gitHubListener       *GitHubListener             // Listens for and handles GH events
+	kubeClient           *kubernetes.Clientset
+	discClient           *discovery.DiscoveryClient
+	dynamicClient        dynamic.Interface
+	webhookNamespace     string
+	triggerProc          *triggerProcessor
+	disableTLS           bool                        // Option to disable TLS listener
+	skipChkSumVerify     bool                        // Option to skip verification of SHA256 checksum of trigger collection
 )
 
 func init() {
@@ -268,6 +269,7 @@ func init() {
 	}
 	flag.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.BoolVar(&disableTLS, "disableTLS", false, "set to use non-TLS listener")
+	flag.BoolVar(&skipChkSumVerify, "skipChecksumVerify", false, "set to skip the verification of trigger collection checksum")
 
 	// init falgs for klog
 	klog.InitFlags(nil)

--- a/test_data/sandbox/sample1/triggers/eventTriggers.yaml
+++ b/test_data/sandbox/sample1/triggers/eventTriggers.yaml
@@ -14,7 +14,7 @@ variables:
   - name: build.tag.promoteNamespaceSuffix # suffix for promoted namespace. Default is project-test.
     value: '"-test"'
   - name: build.registry
-    value: ' "docker-registry.default.svc:5000" '
+    value: ' "image-registry.openshift-image-registry.svc:5000" '
   - name: build.namespace
     value: ' kabanero.namespace ' 
   - name: build.serviceAccount

--- a/webhook_util.go
+++ b/webhook_util.go
@@ -301,18 +301,20 @@ func downloadTrigger(kabaneroIndexURL string, dir string) error {
 	}
 
 	// Verify that the checksum matches the value found in kabanero-index.yaml
-	chkSum, err := sha256sum(triggerArchiveName)
-	if err != nil {
-		return fmt.Errorf("unable to calculate checksum of file %s: %s", triggerArchiveName, err)
-	}
+	if !skipChkSumVerify {
+		chkSum, err := sha256sum(triggerArchiveName)
+		if err != nil {
+			return fmt.Errorf("unable to calculate checksum of file %s: %s", triggerArchiveName, err)
+		}
 
-	if klog.V(5) {
-		klog.Infof("Calculated sha256 checksum of file %s: %s", triggerArchiveName, chkSum)
-	}
+		if klog.V(5) {
+			klog.Infof("Calculated sha256 checksum of file %s: %s", triggerArchiveName, chkSum)
+		}
 
-	if chkSum != triggerChkSum {
-		klog.Fatalf("trigger collection checksum does not match the checksum from the Kabanero index: found: %s, expected: %s",
-			chkSum, triggerChkSum)
+		if chkSum != triggerChkSum {
+			klog.Fatalf("trigger collection checksum does not match the checksum from the Kabanero index: found: %s, expected: %s",
+				chkSum, triggerChkSum)
+		}
 	}
 
 	// Untar the triggers collection

--- a/webhook_util.go
+++ b/webhook_util.go
@@ -20,6 +20,8 @@ import (
 	"archive/tar"
 	"bufio"
 	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"gopkg.in/yaml.v2"
 	"io"
@@ -32,9 +34,10 @@ import (
 	"strings"
 )
 
-/* constants*/
+/* constants */
 const (
 	TRIGGERS = "triggers"
+	CHKSUM = "sha256"
 )
 
 func readFile(fileName string) ([]byte, error) {
@@ -66,6 +69,25 @@ func readJSON(fileName string) (*unstructured.Unstructured, error) {
 	return unstructuredObj, nil
 }
 
+func downloadFileTo(url, path string) error {
+	client := http.Client{}
+	response, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	// Write the file
+	_, err = io.Copy(out, response.Body)
+	return err
+}
+
 func getHTTPURLReaderCloser(url string) (io.ReadCloser, error) {
 
 	client := http.Client{}
@@ -77,7 +99,7 @@ func getHTTPURLReaderCloser(url string) (io.ReadCloser, error) {
 	if response.StatusCode == http.StatusOK {
 		return response.Body, nil
 	}
-	return nil, fmt.Errorf("Unable to read from url %s, http status: %s", url, response.Status)
+	return nil, fmt.Errorf("unable to read from url %s, http status: %s", url, response.Status)
 }
 
 /* Read remote file from URL and return bytes */
@@ -100,40 +122,59 @@ func yamlToMap(bytes []byte) (map[string]interface{}, error) {
 	return myMap, nil
 }
 
-/* Get the URL of where the trigger is stored*/
-func getTriggerURL(collection map[string]interface{}) (string, error) {
+/* Get the URL and sha256 checksum of where the trigger is stored */
+func getTriggerURL(collection map[string]interface{}) (string, string, error) {
 	triggersObj, ok := collection[TRIGGERS]
 	if !ok {
-		return "", fmt.Errorf("collection does not contain triggers: section")
+		return "", "", fmt.Errorf("collection does not contain triggers: section")
 	}
+
 	triggersArray, ok := triggersObj.([]interface{})
 	if !ok {
-		return "", fmt.Errorf("collection does not contain triggers section is not an Arry")
+		return "", "", fmt.Errorf("collection does not contain triggers section is not an Arry")
 	}
+
 	var retURL = ""
+	var retChkSum = ""
+
 	for index, arrayElement := range triggersArray {
 		mapObj, ok := arrayElement.(map[interface{}]interface{})
 		if !ok {
-			return "", fmt.Errorf("triggers section at index %d is not properly formed", index)
+			return "", "", fmt.Errorf("triggers section at index %d is not properly formed", index)
 		}
 		urlObj, ok := mapObj[URL]
 		if !ok {
-			return "", fmt.Errorf("triggers section at index %d is not contain url", index)
+			return "", "", fmt.Errorf("triggers section at index %d does not contain url", index)
 		}
 		url, ok := urlObj.(string)
 		if !ok {
-			return "", fmt.Errorf("triggers section at index %d url is not a string: %s", index, url)
+			return "", "", fmt.Errorf("triggers section at index %d url is not a string: %v", index, urlObj)
 		}
 		retURL = url
+
+		chksumObj, ok := mapObj[CHKSUM]
+		if !ok {
+			return "", "", fmt.Errorf("triggers section at index %d does not contain sha256 checksum", index)
+		}
+		chksum, ok := chksumObj.(string)
+		if !ok {
+			return "", "", fmt.Errorf("triggers section at index %d is not a string: %v", index, chksumObj)
+		}
+		retChkSum = chksum
 	}
 
 	if retURL == "" {
-		return "", fmt.Errorf("Unable to find url from triggers section")
+		return "", "", fmt.Errorf("unable to find url from triggers section")
 	}
-	return retURL, nil
+
+	if retChkSum == "" {
+		return "", "", fmt.Errorf("unable to find sha256 checksum from triggers section")
+	}
+
+	return retURL, retChkSum, nil
 }
 
-/* Merage a directory path with a relative path. Return error if the rectory not a prefix of the merged path after the merge  */
+/* Merge a directory path with a relative path. Return error if the rectory not a prefix of the merged path after the merge  */
 func mergePathWithErrorCheck(dir string, toMerge string) (string, error) {
 	dest := filepath.Join(dir, toMerge)
 	dir, err := filepath.Abs(dir)
@@ -147,7 +188,24 @@ func mergePathWithErrorCheck(dir string, toMerge string) (string, error) {
 	if strings.HasPrefix(dest, dir) {
 		return dest, nil
 	}
-	return dest, fmt.Errorf("Unable to merge directory %s with %s, The merged directory %s is not in a subdirectory", dir, toMerge, dest)
+	return dest, fmt.Errorf("unable to merge directory %s with %s, The merged directory %s is not in a subdirectory", dir, toMerge, dest)
+}
+
+/* Calculate the SHA256 sum of a file */
+func sha256sum(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	_, err = io.Copy(hash, file)
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hash.Sum(nil)), nil
 }
 
 /* gunzip and then untar into a directory */
@@ -182,24 +240,25 @@ func gUnzipUnTar(readCloser io.ReadCloser, dir string) error {
 		if mode.IsRegular() {
 			fileToCreate, err := os.OpenFile(dest, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
-				return fmt.Errorf("Unable to create file %s, error: %s", dest, err)
+				return fmt.Errorf("unable to create file %s, error: %s", dest, err)
 			}
+
 			_, err = io.Copy(fileToCreate, tarReader)
 			closeErr := fileToCreate.Close()
 			if err != nil {
-				return fmt.Errorf("Unable to read file %s, error: %s", dest, err)
+				return fmt.Errorf("unable to read file %s, error: %s", dest, err)
 			}
 			if closeErr != nil {
-				return fmt.Errorf("Unable to close file %s, error: %s", dest, closeErr)
+				return fmt.Errorf("unable to close file %s, error: %s", dest, closeErr)
 			}
 		} else if mode.IsDir() {
 			err = os.MkdirAll(dest, 0755)
 			if err != nil {
-				return fmt.Errorf("Unable to make directory %s, error:  %s", dest, err)
+				return fmt.Errorf("unable to make directory %s, error:  %s", dest, err)
 			}
 			klog.Infof("Created subdirectory %s\n", dest)
 		} else {
-			return fmt.Errorf("unsupported file type within tar archive: file within tar: %s, fiele type: %v", header.Name, mode)
+			return fmt.Errorf("unsupported file type within tar archive: file within tar: %s, field type: %v", header.Name, mode)
 		}
 
 	}
@@ -226,11 +285,38 @@ func downloadTrigger(kabaneroIndexURL string, dir string) error {
 	if err != nil {
 		return err
 	}
-	triggerURL, err := getTriggerURL(kabaneroIndexMap)
+	triggerURL, triggerChkSum, err := getTriggerURL(kabaneroIndexMap)
 	if err != nil {
 		return err
 	}
-	triggerReadCloser, err := getHTTPURLReaderCloser(triggerURL)
+
+	if klog.V(5) {
+		klog.Infof("Found trigger with URL %s and sha256 checksum of %s", triggerURL, triggerChkSum)
+	}
+
+	triggerArchiveName := filepath.Join(dir, "incubator.trigger.tar.gz")
+	err = downloadFileTo(triggerURL, triggerArchiveName)
+	if err != nil {
+		return err
+	}
+
+	// Verify that the checksum matches the value found in kabanero-index.yaml
+	chkSum, err := sha256sum(triggerArchiveName)
+	if err != nil {
+		return fmt.Errorf("unable to calculate checksum of file %s: %s", triggerArchiveName, err)
+	}
+
+	if klog.V(5) {
+		klog.Infof("Calculated sha256 checksum of file %s: %s", triggerArchiveName, chkSum)
+	}
+
+	if chkSum != triggerChkSum {
+		klog.Fatalf("trigger collection checksum does not match the checksum from the Kabanero index: found: %s, expected: %s",
+			chkSum, triggerChkSum)
+	}
+
+	// Untar the triggers collection
+	triggerReadCloser, err := os.Open(triggerArchiveName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Tests

## Correct checksum
```
I1108 00:47:50.096089   45682 webhook_util.go:294] Found trigger with URL https://github.com/hibell/collections/releases/download/v0.3.0/incubator.trigger.tar.gz and sha256 checksum of f99e623d17e6f920e2c4e048b5e01f58dbc23d9215676611138b2a4a65fc8e78
I1108 00:47:50.314867   45682 webhook_util.go:310] Calculated sha256 checksum of file /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook131369521/incubator.trigger.tar.gz: f99e623d17e6f920e2c4e048b5e01f58dbc23d9215676611138b2a4a65fc8e78
I1108 00:47:50.315181   45682 webhook_util.go:259] Created subdirectory /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook131369521
I1108 00:47:50.315367   45682 webhook_util.go:259] Created subdirectory /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook131369521/pull
I1108 00:47:50.315811   45682 webhook_util.go:259] Created subdirectory /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook131369521/push
I1108 00:47:50.315958   45682 webhook_util.go:259] Created subdirectory /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook131369521/tag
I1108 00:47:50.317745   45682 webhook_util.go:325] Leaving downloadTrigger kabaneroIndexURL: https://github.com/hibell/collections/releases/download/v0.3.0/kabanero-index.yaml, directory to store trigger: /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook131369521
I1108 00:47:50.318313   45682 listener.go:85] Starting listener on port 9080
```

## Invalid checksum
```
I1108 00:48:32.693819   45925 webhook_util.go:294] Found trigger with URL https://github.com/hibell/collections/releases/download/v0.3.0/incubator.trigger.tar.gz and sha256 checksum of 099e623d17e6f920e2c4e048b5e01f58dbc23d9215676611138b2a4a65fc8e78
I1108 00:48:32.856172   45925 webhook_util.go:310] Calculated sha256 checksum of file /var/folders/hy/b_gl_2v52tqdbvlgqjmjxv8r0000gn/T/webhook790182224/incubator.trigger.tar.gz: f99e623d17e6f920e2c4e048b5e01f58dbc23d9215676611138b2a4a65fc8e78
F1108 00:48:32.856195   45925 webhook_util.go:314] trigger collection checksum does not match the checksum from the Kabanero index: found: f99e623d17e6f920e2c4e048b5e01f58dbc23d9215676611138b2a4a65fc8e78, expected: 099e623d17e6f920e2c4e048b5e01f58dbc23d9215676611138b2a4a65fc8e78
```